### PR TITLE
Add a Trademarks page

### DIFF
--- a/wordpress-org/trademarks.md
+++ b/wordpress-org/trademarks.md
@@ -1,0 +1,87 @@
+# Trademarks
+
+[alert]WordPress.org (and the WordPress.org plugin review team) does not provide legal advice on how to use Trademarks within your plugin. You should seek advice on how to comply with a trademark from either the trademark owner, or a legal advisor. This page is a guide only, and does not provide you with any rights or legal basis on using a term.<br></p><p>This page exists to document the existing Trademark checks included in the WordPress.org plugin directory.[/alert]
+
+The WordPress.org plugin directory contains some automated checks which detect and block common incorrect usage of Trademarks. This detection is not 100% accurate in all cases, and may provide false positives (ie. It may block something you may use) or false negatives (It may not detect something you cannot do).
+
+Trademarks apply to more than just the name of a plugin, they also apply to content within Banner images, Icons, Screenshots, the Description, the Slug (URL), your domain names, and all other areas within a plugin or it's description on WordPress.org.
+
+**A Trademark Violation occurs when your usage of a trademark is either a) May mislead or confuse people about your affiliation to it, or b) Not in compliance with the owners usage terms.**
+
+The checks we perform are in three main categories:
+1. Manual review; The plugin review team may (at their discretion), check that they feel your plugin (submission, or existing plugin) is respectful of any Trademark. This may include trademarks listed here, in response to any complaints from trademark holders, or as part of other review processes.
+2. Automatic detection of trademarks which your plugin name
+   - **Cannot contain.** These are trademarks which their owners have requested us block in it's entirety, either due to trademark usage guidelines or ongoing abuse by plugin authors.
+   - **Cannot begin with.** These are trademarks which are commonly abused and cause ambiguity as the other ownership of the plugin.
+
+## Trademarks your plugin cannot use _at all_
+
+This is a list of trademarks which the owner has requested us to block on the WordPress.org plugin directory. The usage of these terms within a plugin name, or in any other form that does not comply with the trademark owners guidelines will result in the plugin being **suspended without notice**.
+
+1. All In One WP Migration
+2. Booking.com
+3. [Facebook](https://about.meta.com/uk/brand/resources/meta/our-trademarks), [FB Messenger](https://about.meta.com/uk/brand/resources/meta/our-trademarks), [Instagram](https://about.meta.com/uk/brand/resources/meta/our-trademarks), [Oculus](https://about.meta.com/uk/brand/resources/meta/our-trademarks), &amp; [Whatsapp](https://about.meta.com/uk/brand/resources/meta/our-trademarks)
+4. FeedBurner
+5. Trustpilot
+6. Tweet
+7. Webpush VN
+8. Watson
+9. [Woo](https://woocommerce.com/trademark-guidelines/) &amp; [WooCommerce](https://woocommerce.com/trademark-guidelines/) (See the ["for use" exceptions](#for-use-exceptions) below.)
+10. [WordPress](https://wordpressfoundation.org/trademark-policy/) (See the [note on "WP"](#words-that-are-blocked-which-are-not-trademarks) below.)
+11. Yoast
+
+Variations on those trademarks are also not allowed, for example, replacing `W` with `vv` is not accepted.
+
+Acronyms of these trademarks (where the acronym is not trademarked) may be acceptable.
+
+## Trademarks your plugin _cannot begin with_
+
+Your plugin name **cannot start with a trademark which you do not represent**. Below is a list of trademarks which we have explicit checks in place for, but this is only a guide and not at all a complete list. These trademarks may be used elsewhere within the plugin name if in compliance with the trademark usage guidelines.
+
+_Adobe, AdSense, Advanced Custom Fields, AdWords, Akismet, Amazon, Android, Apple, AWS, bbPress, Bing, Bootstrap, BuddyPress, Contact Form 7, Cloudflare, Cpanel, Disqus, Divi, Dropbox, Easy Digital Downloads, Elementor, Envato, Facebook, Fedex, Firefox, Font Awesome, Github, GiveWP, Google, Gravity Forms, Gtmetrix, Hubspot, Instagram, Internet Explorer, iOS, Jetpack, Macintosh, MacOS, Mailchimp, Microsoft, Ninja Forms, OnlyFans, Opera, Paddle, Paypal, Pinterest, Skype, Stripe, Tiktok, Twitch, Twitter, UPS, USPS, Windows, Woo, WP Mail Smtp, Yandex, Yahoo, Youtube_
+
+Some acronyms and similar words for these may also be included.
+
+## "for use" exceptions
+
+Some trademark owners allow their trademarks to be used as part of a plugin name when your plugin extends it.
+
+_[WooCommerce](https://woocommerce.com/trademark-guidelines/)_ is an example of a trademark which cannot be used at all in a plugin name, unless it's being used to describe that a plugin extends it. For example, _PaymentGateway **for WooCommerce**_ is acceptable, but _"WooCommerce PaymentGateway"_ is not.
+
+Other trademarks included on this page may provide a for-use exception in their usage guidelines.
+
+## Words that are blocked, which are not trademarks
+
+We include some words in our trademark checks which are not trademarked, which are either commonly misused, or just do not belong in a plugin name.
+
+**"WP"** - Use of the WordPress trademark within plugin names is not acceptable, although "WP" **is acceptable**, it's often used to bypass the trademark check and replaced with "WordPress" after review (Which is NOT acceptable). We do discourage the use of "WP" within a plugin name, but if you're certain that you wish to use this please contact the plugin review team.
+
+**"Gutenberg"** - The Gutenberg name is commonly misused by plugins, while this is not a trademark, it's also not the correct name to reference _The WordPress Editor_, Gutenberg is simply the project name for it. Plugins are encouraged to describe their plugin using descriptives such as "Block" or "Editor".
+
+**"Plugin"** - Your _plugin_ on WordPress.org is a plugin. Your plugin doesn't need to explicitly state that it's a plugin, nor does it need to state that it's a _WordPress Plugin_.
+
+## For Trademark Owners
+
+The plugin review team cannot proactively review for (or defend) uses of your trademark(s) within our directory. We rely upon your reports and public trademark-usage websites to educate plugin authors.
+
+Plugins must remain in compliance with **all trademarks**, whether we have automated rules in place for them or not.
+
+### Reporting trademark violations
+
+If a plugin on WordPress.org/plugins is using your trademarks (Words or Marks/Images) incorrectly, we encourage you to contact the plugin author directly.
+
+If you are unable to make contact or they do not take steps to become compliant, [please contact the plugins team](mailto:plugins@wordpress.org) to report the violation. Please include the URL(s) of the plugin(s) and confirmation that you legally represent the trademarked term (For example, emailing from a company email address).
+
+
+### Can you add my trademark to the list of blocked trademarks?
+
+Possibly. Our automated trademark rules cannot contain every trademark ever registered in every country. The trademarks which we have rules in place for are limited to those which are often misused or abused on the plugin directory. If you find your trademark being misused on WordPress.org **often** please raise it with us with your next trademark violation report.
+
+
+## Individual trademark usage agreements
+
+For simplicity, WordPress.org does not accept trademark use exceptions granted to a Plugin author. These agreements can be rescinded by trademark owners at a later date, and often cannot verify the agreement is legitimate or valid.
+
+Instead, We require that the trademark owner submit/own the plugin. This ensures that the plugin does not need to be removed later-on if the usage changes, or the trademark owner launches their own plugin.
+
+Trademark owners can submit plugins using their own legal trademarks, regardless of these rules. These rules are not intended to prevent acceptable use, only limit misuse.


### PR DESCRIPTION
Currently the handbook contains mentions about using trademarks in the FAQ, but this deserves a far more detailed page as we have ongoing questions about why a plugin author is blocked from using a plugin name.

This is a draft at creating a dedicated page.

Current texts:
https://github.com/WordPress/developer-plugins-handbook/blob/b48546a60d540a58097d8a2388f34a2f5bafd64b/wordpress-org/plugin-developer-faq/index.md?plain=1#L41-L43

https://github.com/WordPress/developer-plugins-handbook/blob/b48546a60d540a58097d8a2388f34a2f5bafd64b/wordpress-org/plugin-developer-faq/index.md?plain=1#L301-L319

https://github.com/WordPress/developer-plugins-handbook/blob/b48546a60d540a58097d8a2388f34a2f5bafd64b/wordpress-org/plugin-developer-faq/index.md?plain=1#L345-L347

Guideline:
https://github.com/WordPress/developer-plugins-handbook/blob/b48546a60d540a58097d8a2388f34a2f5bafd64b/wordpress-org/detailed-plugin-guidelines/index.md?plain=1#L167-L173