### PR TITLE
Added Plugin Check as a plugin tool for developers

### DIFF
--- a/developer-tools/helper-plugins/index.md
+++ b/developer-tools/helper-plugins/index.md
@@ -1,5 +1,13 @@
 # Helper Plugins
 
+## Plugin Check
+
+Plugin Check is a tool for testing whether your plugin meets the required standards for the WordPress.org plugin directory. With this plugin you will be able to run most of the checks used for new submissions, and check if your plugin meets the requirements.
+
+Additionally, the tool flags violations or concerns around plugin development best practices, from basic requirements like correct usage of internationalization functions to accessibility, performance, and security best practices.
+
+[Visit Plugin Check](https://wordpress.org/plugins/plugin-check/)
+
 ## Query Monitor
 
 Query Monitor is a debugging plugin for anyone developing with WordPress. You can view debugging and performance information on database queries, hooks, conditionals, HTTP requests, redirects and more. It has some advanced features not available in other debugging plugins, including automatic AJAX debugging and the ability to narrow down things by plugin or theme.


### PR DESCRIPTION
I've added the plugin check plugin as suggested in the issue [#445](https://github.com/WordPress/plugin-check/issues/445).