### PR TITLE
fixes issue #29 It would be appropriate to move the row.

### DIFF
--- a/users/working-with-user-metadata/index.md
+++ b/users/working-with-user-metadata/index.md
@@ -147,9 +147,9 @@ update_user_meta(
 );
 ```
 
-#### Delete
-
 Please refer to the Function Reference about [`update_user_meta()`](https://developer.wordpress.org/reference/functions/update_user_meta/) for full explanation about the used parameters.
+
+#### Delete
 
 ```
 delete_user_meta(


### PR DESCRIPTION
It would be appropriate to move the content of line 152 under ‘#### Update’ instead of under ‘#### Delete’.

line 152: 'Please refer to the Function Reference about [`update_user_meta()`](https://developer.wordpress.org/reference/functions/update_user_meta/) for full explanation about the used parameters.'

in the Japanese translated version, the line has already been moved.


Working remote repository (main)
![image](https://github.com/user-attachments/assets/1ef54ed1-c4c5-4cb9-9162-6cbb35b4e7b6)

Branch from there
![image](https://github.com/user-attachments/assets/2f3ede1e-0429-41fa-bd57-9740b6241b69)
The modified files are now stored here.