### PR TITLE
fixes issue #30 Unnecessary line breaks appear to be inserted at the end of lines. (partial 1)

### DIFF
--- a/privacy/adding-the-personal-data-eraser-to-your-plugin/index.md
+++ b/privacy/adding-the-personal-data-eraser-to-your-plugin/index.md
@@ -73,8 +73,7 @@ function wporg_remove_location_meta_from_comments_for_email( $email_address, $pa
 
 The next thing the plugin needs to do is to register the callback by filtering the eraser array using the [`wp_privacy_personal_data_erasers`](https://developer.wordpress.org/reference/hooks/wp_privacy_personal_data_erasers/) filter.
 
-When registering you provide a friendly name for the eraser (to aid in debugging – this friendly name is not shown to anyone at this time)  
-and the callback, e.g.
+When registering you provide a friendly name for the eraser (to aid in debugging – this friendly name is not shown to anyone at this time) and the callback, e.g.
 
 ```
 /**


### PR DESCRIPTION
At the end of line 76, an unnecessary line break appears to have been inserted. The content of line 77 should continue at the end of line 76.

line 76-77: ‘When registering you provide a friendly name for the eraser (to aid in debugging – this friendly name is not shown to anyone at this time) 
and the callback, e.g.’

Working remote repository (main)
![image](https://github.com/user-attachments/assets/7f989265-2de3-4651-9420-3994bda95ce1)

Branch from there
![image](https://github.com/user-attachments/assets/93455dd3-ceb2-493b-a77b-b60314574d42)

![image](https://github.com/user-attachments/assets/6cdc5f63-29a3-4725-8169-5922898a6598)

The modified files are now stored here.