### PR TITLE
fixes issue #30 Unnecessary line breaks appear to be inserted at the end of lines. (Partial 2)

### DIFF
--- a/hooks/actions/index.md
+++ b/hooks/actions/index.md
@@ -54,8 +54,7 @@ A function with a priority of 11 will run _after_ a function with a priority of 
 
 The second way that callback function order is determined is simply by the order in which it was registered _within the same priority value_. So if two callback functions are registered for the same hook with the same priority, they will be run in the order that they were registered to the hook.
 
-For example, the following callback functions are all registered to the  
-`init` hook, but with different priorities:
+For example, the following callback functions are all registered to the `init` hook, but with different priorities:
 
 ```
 add_action( 'init', 'wporg_callback_run_me_late', 11 );


### PR DESCRIPTION
At the end of line 57, an unnecessary line break appears to have been inserted. The content of line 58 should continue at the end of line 57.

line 57-58: ‘For example, the following callback functions are all registered to the 
`init` hook, but with different priorities:’

Working remote repository (main)
![image](https://github.com/user-attachments/assets/5fe93890-0383-48e1-84de-0b8e4c190631)

Branch from there
![image](https://github.com/user-attachments/assets/06ad10fa-bc06-4bdf-90b8-1bd91392a3a7)

![image](https://github.com/user-attachments/assets/5c06aee7-8835-4865-bf2b-01bf8dfdd7b4)

The modified files are now stored here.