### PR TITLE
Add Launchpad into the boilerplate listing

### DIFF
--- a/plugin-basics/best-practices/index.md
+++ b/plugin-basics/best-practices/index.md
@@ -181,5 +181,6 @@ These also serve as further examples of different yet comparable architectures.
 - [WordPress Plugin Bootstrap](https://github.com/claudiosanches/wordpress-plugin-boilerplate): Basic bootstrap to develop WordPress plugins using Grunt, Compass, GIT, and SVN.
 - [WP Skeleton Plugin](https://github.com/ptahdunbar/wp-skeleton-plugin): Skeleton plugin that focuses on unit tests and use of composer for development.
 - [WP CLI Scaffold](https://developer.wordpress.org/cli/commands/scaffold/plugin/): The Scaffold command of WP CLI creates a skeleton plugin with options such as CI configuration files.
+- [WP Launchpad](https://wp-launchpad.gitbook.io/launchpad): A modular framework to create modern PHP standards WordPress plugins.
 
 Of course, you could take different aspects of these and others to create your own custom boilerplate.


### PR DESCRIPTION
During WC Sofia I got as a question why my framework Launchpad wasn't listed at this level while there were some abandoned projects inside the listing.

Let's answer this question together by letting me know what are the requirements to be inside that listing and let's see if Launchpad meets those criteria. 

PS: While looking at this documentation, I can see notions there are quite outdated, it might be useful to update it with new notions that have started emerging in the meanwhile.
Is there a process to enhance this documentation or I can do it just by creating some PR like this one?