### PR TITLE
Common issues: fix broken link

### DIFF
--- a/wordpress-org/common-issues/index.md
+++ b/wordpress-org/common-issues/index.md
@@ -46,7 +46,7 @@ echo esc_html(sanitize_text_field($_POST['example']));
 
 #### Sanitize: Using filter functions to sanitize
 
-**Note**: When using functions like `filter_var`, `filter_var_array`, `filter_input` and/or `filter_input_array` you will need to [set the FILTER parameter to any kind of filter that sanitizes the input](https://www.php.net/manual/en/filter.filters.php).
+**Note**: When using functions like `filter_var`, `filter_var_array`, `filter_input` and/or `filter_input_array` you will need to [set the FILTER parameter to any kind of filter that sanitizes the input](https://www.php.net/manual/en/filters.php).
 
 Leaving the filter parameter empty, PHP by default will apply the filter "FILTER_DEFAULT" **which is not sanitizing at all**.
 


### PR DESCRIPTION
There is a link about sanitizing the input, but this link is not found:

https://www.php.net/manual/en/filter.filters.php

According to the Wayback Machine history, it seems that this page was removed at the end of 2024:

https://web.archive.org/web/20240801000000*/https://www.php.net/manual/en/filter.filters.php

This URL seems to have pointed to a page titled "Types of filters".

https://web.archive.org/web/20241109195847/https://www.php.net/manual/en/filter.filters.php

This page no longer exists, so I have replaced it with a link to a similar page titled "List of Available Filters".
