### PR TITLE
Adding the Personal Data Eraser to Your Plugin: Fix incorrect word

### DIFF
--- a/privacy/adding-the-personal-data-eraser-to-your-plugin/index.md
+++ b/privacy/adding-the-personal-data-eraser-to-your-plugin/index.md
@@ -14,7 +14,7 @@ The eraser callback interface is designed to be as simple as possible. An eraser
 
 The eraser callback replies whether items containing personal data were erased, whether any items containing personal data were retained, an array of messages to present to the admin (explaining why items that were retained were retained) and whether it is done or not. If an eraser callback reports that it is not done, it will be called again (in a separate request) with the page parameter incremented by 1.
 
-When all the exporters have been called to completion, the admin user interface is updated to show whether or not all personal data found was erased, and any messages explaining why personal data was retained.
+When all the erasers have been called to completion, the admin user interface is updated to show whether or not all personal data found was erased, and any messages explaining why personal data was retained.
 
 Let's work on a hypothetical plugin which adds commenter location data to comments. Let's assume the plugin has used [`add_comment_meta`](https://developer.wordpress.org/reference/functions/add_comment_meta/) to add location data using `meta_key`'s of `latitude` and `longitude`.
 


### PR DESCRIPTION
https://developer.wordpress.org/plugins/privacy/adding-the-personal-data-eraser-to-your-plugin/

This page describes the eraser, not the exporter.